### PR TITLE
fix: downgrade encase to bevy version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ bevy_render = { version = "0.17.0-rc.1", optional = true }
 bevy_shader = { version = "0.17.0-rc.1", optional = true }
 bevy_tasks = { version = "0.17.0-rc.1", optional = true }
 bevy_transform = { version = "0.17.0-rc.1", optional = true }
-encase = { version = "0.12", optional = true }
+encase = { version = "0.11", optional = true }
 wgpu-types = { version = "26.0", optional = true }
 
 # `bevy_ui` feature


### PR DESCRIPTION
Bevy still uses `encase@0.11`. compilation will fail if using the `render` feature.